### PR TITLE
Using C.malloc() instead of new() to avoid the runtime error about passing a Go pointer to C.

### DIFF
--- a/slconn.go
+++ b/slconn.go
@@ -42,12 +42,14 @@ func (s *SLCD) SetSLAddr(sladdr string) {
 	(((*_Ctype_SLCD)(s)).sladdr) = C.CString(sladdr)
 }
 func (s *SLCD) Collect() (*SLPacket, int) {
-	slpack := new(C.struct_slpacket_s)
+	// use C's malloc() instead of Go's new() to allocate memory and avoid Go garbage
+	// collecting the memory while C is accessing it.  Use SLPacket's Free() to free memory.
+	slpack := (*C.struct_slpacket_s)(C.malloc((C.sizeof_struct_slpacket_s)))
 	err := (int)(C.sl_collect((*C.struct_slcd_s)(s), &slpack))
 	return (*SLPacket)(slpack), err
 }
 func (s *SLCD) CollectNB() (*SLPacket, int) {
-	slpack := new(C.struct_slpacket_s)
+	slpack := (*C.struct_slpacket_s)(C.malloc((C.sizeof_struct_slpacket_s)))
 	err := (int)(C.sl_collect_nb((*C.struct_slcd_s)(s), &slpack))
 	return (*SLPacket)(slpack), err
 }

--- a/slpacket.go
+++ b/slpacket.go
@@ -59,3 +59,7 @@ func (p *SLPacket) ParseRecord(blktflag, unpackflag int8) *SLMSRecord {
 	C.sl_msr_parse((*C.struct_SLlog_s)(nil), (*_Ctype_char)(unsafe.Pointer(&p.msrecord[0])), &msr, (C.int8_t)(blktflag), (C.int8_t)(unpackflag))
 	return (*SLMSRecord)(msr)
 }
+
+func (p *SLPacket) Free() {
+	C.free(unsafe.Pointer(p))
+}


### PR DESCRIPTION
The error is: 'runtime error: go argument has Go pointer to Go pointer'.  We avoid this by setting the environment variable GODEBUG=cgocheck=0 but it seems like the better option is to avoid passing a go pointer.

This PR switches to using a malloc'ed pointer and adds a Free function.  The tests pass and the runtime error goes away.  The shakenz-slink app will need to use a "defer p.Free()" (main.go:81) to avoid a memory leak.

Merry Christmas!